### PR TITLE
minor fix of test dataset

### DIFF
--- a/dataset/afmDataset.py
+++ b/dataset/afmDataset.py
@@ -58,10 +58,8 @@ class AFMTestDataset(data.Dataset):
             with open(osp.join(self.data_root,'test.txt'),'r') as handle:
                 filename = [f.rstrip('\n') for f in handle.readlines()]
         
-            dataset = []
-            for f in filename:
-                dataset += {'filename': f,
-                            'lines': np.array([0,0,0,0],dtype=np.float32)}
+            dataset = [{'filename': f, 'lines': np.array([0,0,0,0],dtype=np.float32)} for f in filename]
+
         else:
             raise NotImplementedError()
         


### PR DESCRIPTION
Fix test dataset when only `file_list.txt` is provided.

The problem is `list += dict` will append keys to the list:
```python
a = []
a += {'x': 1, 'y': 2}
# a will be ['x', 'y'] instead of [{'x': 1, 'y': 2}]
```